### PR TITLE
fix: add missing chunk_first and chunk_len params to test functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,8 @@ mod tests {
         let payload: [u8; 32] = [1; 32];
         let display = Baid64Display::with(
             hri, payload, true, // chunking
+            8, // chunk_first
+            7, // chunk_len
             true, // prefix
             true, // suffix (mnemonic)
             true, // embed_checksum
@@ -366,6 +368,8 @@ mod tests {
         let display = Baid64Display::with(
             hri, payload, // Using LEN=4 for simplicity in test
             false,   // chunking
+            8,       // chunk_first
+            7,       // chunk_len
             true,    // prefix
             true,    // suffix (mnemonic)
             true,    // embed_checksum
@@ -491,6 +495,8 @@ mod tests {
         let payload: [u8; 32] = [3; 32];
         let display = Baid64Display::with(
             hri, payload, true, // chunking
+            8, // chunk_first
+            7, // chunk_len
             true, // prefix
             true, // suffix
             true, // embed_checksum


### PR DESCRIPTION
## Summary
- Add missing `chunk_first` and `chunk_len` parameters to three test functions that call `Baid64Display::with()`
- Values match the trait's default constants (`CHUNK_FIRST = 8`, `CHUNK_LEN = 7`)

## Problem
The `Baid64Display::with()` function requires 8 arguments but three test functions were only providing 6:
- `test_baid64_display()` 
- `test_baid64_display_fmt()`
- `test_baid64_display_chunking()`

This caused compilation errors:
```
error[E0061]: this function takes 8 arguments but 6 arguments were supplied
```

## Test plan
- [x] `cargo test` passes (all 6 tests)
- [x] Verified values match trait defaults and `new()` constructor

Fixes #3